### PR TITLE
Prepare upgrade to 4.4

### DIFF
--- a/manifests/repo/scylla_repo.pp
+++ b/manifests/repo/scylla_repo.pp
@@ -5,7 +5,7 @@ class scylla::repo::scylla_repo (
   $release    = $::os['distro']['codename'],
   $repos      = 'non-free',
   $apt_key    = '5e08fbd8b5d6ec9c',
-  $location   = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2',) {
+  $location   = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.4',) {
 
     package { 'gnupg2':
       ensure => present,

--- a/manifests/repo/scylla_repo.pp
+++ b/manifests/repo/scylla_repo.pp
@@ -1,11 +1,11 @@
 # For Debian 9 only
 class scylla::repo::scylla_repo (
-  $key_id  = '0C7BD5EFB64F8D4F9ACF4D3284ACD5B2D02945ED',
-  $key_url = 'https://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-stretch/Debian_9.0/Release.key',
+  $key_id     = '7752A0722F457FB76C0F44985E08FBD8B5D6EC9C',
   $key_server = 'keyserver.ubuntu.com',
-  $release = 'stretch',
-  $repos = 'non-free',
-  $location = 'https://repositories.scylladb.com/scylla/downloads/scylladb/b956f642-36ba-4ba7-a565-68df8f10acb5/scylla/deb/debian/scylladb-3.0',) {
+  $release    = $::os['distro']['codename'],
+  $repos      = 'non-free',
+  $apt_key    = '5e08fbd8b5d6ec9c',
+  $location   = 'https://repositories.scylladb.com/scylla/downloads/scylladb/deb/scylla/deb/debian/scylladb-4.2',) {
 
     package { 'gnupg2':
       ensure => present,
@@ -17,25 +17,17 @@ class scylla::repo::scylla_repo (
         #include apt::update
         apt::key {'scylla':
           id     => $key_id,
-          source => $key_url,
           server => 'keyserver.ubuntu.com',
-          options => 'http-proxy="http://squid.zattoo.com:3128 " --recv-keys 17723034C56D4B19',
-
+          options => 'http-proxy="http://squid.zattoo.com:3128 " --recv-keys "${apt_key}"',
         }
 
         apt::source { 'scylla.source.https.list':
-          location => "https://repositories.scylladb.com/scylla/downloads/scylladb/b956f642-36ba-4ba7-a565-68df8f10acb5/scylla/deb/debian/scylladb-3.0",
-          release  => $::os['distro']['codename'],
-          repos    => 'non-free',
+          location => "${location}",
+          release  => "${release}",
+          repos    => "${repos}",
           notify   => Exec['apt_update'],
         }
-        apt::source { 'scylla.source.http.list':
-          location => "http://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-stretch/Debian_9.0/",
-          release  => './',
-          repos    => '',
-          notify   => Exec['apt_update'],
 
-        }
       }
       default: {
         warning("OS family ${::osfamily} not supported")


### PR DESCRIPTION
This will hopefully pull 4.4 packages. Do I need to change the key_id, too? GPG key seems to be expired.